### PR TITLE
special_services_requested needs to default to an array

### DIFF
--- a/lib/shippinglogic/fedex/ship.rb
+++ b/lib/shippinglogic/fedex/ship.rb
@@ -164,7 +164,7 @@ module Shippinglogic
       attribute :ship_time,                   :datetime,    :default => lambda { |shipment| Time.now }
       attribute :service_type,                :string
       attribute :dropoff_type,                :string,      :default => "REGULAR_PICKUP"
-      attribute :special_services_requested,  :array
+      attribute :special_services_requested,  :array,       :default => []
       attribute :signature,                   :string
       
       # misc options


### PR DESCRIPTION
this is so the signature portion of Request::build_package works properly
